### PR TITLE
Removes api service from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,6 @@
 version: '3'
 
 services:
-  api:
-    container_name: kawaiibot_api
-    hostname: api
-    build: ./kawaiibot_api
   bot:
     container_name: kawaiibot
     build: .


### PR DESCRIPTION
API service is not built within the project. See `config.properties.example` for 
API configuration.